### PR TITLE
Optimize GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,15 +4,18 @@ name: Deploy Docs to GitHub Pages
 # * Always run on "main"
 # * Run on PRs that target the "main" branch and have changes in the "docs" folder or this workflow
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
       - 'docs/**'
       - '.github/workflows/deploy-docs.yml'
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual trigger'
+        required: true
+        default: ''
 
 # If triggered by a PR, it will be in the same group. However, each commit on main will be in its own unique group
 concurrency:

--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -9,8 +9,6 @@ on:
         description: 'Reason for manual trigger'
         required: true
         default: ''
-  schedule:
-    - cron: '30 22 * * *'  # Runs at 10:30pm UTC every day
 
 env:
   N_PROCESSES: 10 # Global configuration for number of parallel processes for evaluation

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,20 @@ name: Lint
 # Always run on "main"
 # Always run on PRs
 on:
-  push:
-    branches:
-    - main
   pull_request:
+    paths:
+      # Frontend files
+      - 'frontend/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.eslintrc.js'
+      - '.prettierrc'
+      # Python files
+      - '**.py'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - '.pre-commit-config.yaml'
+      - '.github/workflows/lint.yml'
 
 # If triggered by a PR, it will be in the same group. However, each commit on main will be in its own unique group
 concurrency:

--- a/.github/workflows/py-unit-tests.yml
+++ b/.github/workflows/py-unit-tests.yml
@@ -5,10 +5,13 @@ name: Run Python Unit Tests
 # * Always run on "main"
 # * Always run on PRs
 on:
-  push:
-    branches:
-      - main
   pull_request:
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - '.github/workflows/py-unit-tests.yml'
+      - 'tests/**'
 
 # If triggered by a PR, it will be in the same group. However, each commit on main will be in its own unique group
 concurrency:


### PR DESCRIPTION
This PR optimizes GitHub Actions workflows to run more sparingly:

- Remove scheduled runs from integration tests
- Remove push triggers to main branch
- Add path filters to lint and unit test workflows
- Add manual trigger to docs deployment
- Keep evaluation workflow as is (already optimized)

These changes will significantly reduce the number of GitHub Actions runs while still maintaining quality control:
- Integration tests will only run when explicitly requested
- Unit tests will only run when relevant files are changed in PRs
- Lint checks will only run when relevant frontend/Python files change
- No more automatic runs on pushes to main branch
- Added manual triggers where appropriate